### PR TITLE
Update f-string to use python 3.5 compatible .format

### DIFF
--- a/src/04-asyncio/producer_consumer/prod_sync/sync_program.py
+++ b/src/04-asyncio/producer_consumer/prod_sync/sync_program.py
@@ -20,7 +20,7 @@ def generate_data(num: int, data: list):
         item = idx*idx
         data.append((item, datetime.datetime.now()))
 
-        print(colorama.Fore.YELLOW + f" -- generated item {idx}", flush=True)
+        print(colorama.Fore.YELLOW + " -- generated item {}".format(idx), flush=True)
         time.sleep(random.random() + .5)
 
 


### PR DESCRIPTION
The 04-asyncio producer_consumer demo uses f-strings which is not supported in python 3.5 (which is a supported python version in this course).