### PR TITLE
Update f-string to use python 3.5 compatible .format

### DIFF
--- a/src/04-asyncio/producer_consumer/prod_async/async_program.py
+++ b/src/04-asyncio/producer_consumer/prod_async/async_program.py
@@ -29,7 +29,7 @@ async def generate_data(num: int, data: asyncio.Queue):
         item = idx*idx
         await data.put((item, datetime.datetime.now()))
 
-        print(colorama.Fore.YELLOW + f" -- generated item {idx}", flush=True)
+        print(colorama.Fore.YELLOW + " -- generated item {}".format(idx), flush=True)
         await asyncio.sleep(random.random() + .5)
 
 


### PR DESCRIPTION
The 04-asyncio producer_consumer async demo uses f-strings which is not supported in python 3.5.