### PR TITLE
Fix "deprecated `trio.Queue`" warning

### DIFF
--- a/src/09-built-on-asyncio/requirements.txt
+++ b/src/09-built-on-asyncio/requirements.txt
@@ -1,6 +1,6 @@
 unsync
-trio
-trio_asyncio
+trio==0.8.0
+trio_asyncio==0.9.1
 
 aiohttp
 cchardet


### PR DESCRIPTION
### Overview

It looks like `trio.Queue` was deprecated as of **trio 0.9.0** ([see here](https://trio.readthedocs.io/en/stable/history.html#id13)).

This PR pins trio to the version just before this deprecation and then pins **trio_async** to its latest version that was compatible with **trio 0.8.0**.

---

#### Error message being addressed

This was the error being thrown when using the latest version of trio & trio_async:

```
Traceback (most recent call last):
  File "prod_trio.py", line 30, in <module>
    async def generate_data(num: int, data: trio.Queue):
  File ".../site-packages/trio/_deprecate.py", line 125, in __getattr__
    raise AttributeError(name)
AttributeError: Queue
```

